### PR TITLE
.travis.yml: Test build on thumbv7em-none-eabihf targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,30 @@ branches:
 install:
   - rustup component add rustfmt
   - rustup component add clippy
+  - rustup target add thumbv7em-none-eabihf # for NeoTrellis M4's SAMD51
 
-script:
-  - cargo fmt -- --check
-  - cargo clippy
-  - cargo build --no-default-features --release
-  - cargo build --release
-  - cargo test --no-default-features
-  - cargo test
-  - cargo test --no-default-features --release
-  - cargo test --release
-  - cargo doc --all --no-deps
+matrix:
+  include:
+    - name: rustfmt
+      script:
+        - cargo fmt -- --check
+    - name: clippy
+      script:
+        - cargo clippy
+    - name: build
+      script:
+        - cargo build --no-default-features --release
+        - cargo build --release
+    - name: build (thumbv7em-none-eabihf target)
+      script:
+        - cargo build --target thumbv7em-none-eabihf --no-default-features
+        - cargo build --target thumbv7em-none-eabihf --no-default-features --release
+    - name: test
+      script:
+        - cargo test --no-default-features
+        - cargo test
+        - cargo test --no-default-features --release
+        - cargo test --release
+    - name: doc build
+      script:
+        - cargo doc --all --no-deps


### PR DESCRIPTION
This is the target for the SAMD51 used in the NeoTrellis M4, which is the primary intended target / use case for PureZen.