### PR TITLE
v0.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
+## [v0.0.2] (2019-02-20)
+
+- Translate `pd::Context`, `message::Send`, and `message::send::Controller`
+  into Rust ([#16])
+
 ## [v0.0.1] (2019-02-19)
 
 - Initial release
 
+[v0.0.2]: https://github.com/NeoBirth/PureZen/pull/17
+[#16]: https://github.com/NeoBirth/PureZen/pull/16
 [v0.0.1]: https://github.com/NeoBirth/PureZen/pull/14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "purezen"
-version     = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.0.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>", "Martin Roth <mhroth@rjdj.me>"]
 license     = "LGPL-3.0"
 edition     = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/PureZen/master/purezen.png",
-    html_root_url = "https://docs.rs/purezen/0.0.1"
+    html_root_url = "https://docs.rs/purezen/0.0.2"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
- Translate `pd::Context`, `message::Send`, and `message::send::Controller` into Rust (#16)